### PR TITLE
Fix Go linter CI job

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,6 +14,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.17.1'
+      - name: Install Protoc
+        uses: arduino/setup-protoc@v1
+        with:
+          version: '3.x'
+      - name: Compile Protocol Buffer Definitions
+        working-directory: backend
+        run: |
+          go install google.golang.org/protobuf/cmd/protoc-gen-go@latest
+          go install google.golang.org/grpc/cmd/protoc-gen-go-grpc@latest
+          make proto
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v2
         with:

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -32,3 +32,4 @@ jobs:
         uses: golangci/golangci-lint-action@v2
         with:
           working-directory: backend
+          skip-pkg-cache: true

--- a/backend/internal/adapters/primary/handlers/internal/gemservice.go
+++ b/backend/internal/adapters/primary/handlers/internal/gemservice.go
@@ -4,9 +4,10 @@ import (
 	"context"
 	"fmt"
 
+	"google.golang.org/protobuf/types/known/timestamppb"
+
 	"github.com/hansel-app/hansel/internal/core/domain/gems"
 	"github.com/hansel-app/hansel/protobuf/gemsapi"
-	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 type gemService struct {
@@ -44,7 +45,10 @@ func (s *gemService) Get(c context.Context, r *gemsapi.GetRequest) (*gemsapi.Get
 	}, nil
 }
 
-func (s *gemService) GetPendingCollectionByUser(c context.Context, r *gemsapi.GetPendingCollectionByUserRequest) (*gemsapi.GetPendingCollectionByUserResponse, error) {
+func (s *gemService) GetPendingCollectionByUser(
+	c context.Context,
+	r *gemsapi.GetPendingCollectionByUserRequest,
+) (*gemsapi.GetPendingCollectionByUserResponse, error) {
 	gems, err := s.usecases.GetPendingCollectionByUser(r.UserId)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Issue is caused by the Protocol Buffer definitions not being compiled prior to the Go linter being run. This resulted in the linter to fail due to missing imports.

Note that it is necessary to set the `skip-pkg-cache` argument to `true` to prevent the `golangci-lint-action` from caching or restoring `~/go/pkg`. Otherwise, it will conflict with the installation of the Protocol Buffer code generation plugins.