### PR TITLE
Fix being unable to login

### DIFF
--- a/backend/internal/core/domain/users/user.go
+++ b/backend/internal/core/domain/users/user.go
@@ -1,8 +1,8 @@
 package users
 
 type User struct {
-	ID             int64
-	Username       string
-	Email          string
-	HashedPassword string
+	ID             int64  `db:"id"`
+	Username       string `db:"username"`
+	Email          string `db:"email"`
+	HashedPassword string `db:"hashed_password"`
 }


### PR DESCRIPTION
The `hashed_password` column in the database was not being correctly mapped to the `HashedPassword` struct. I believe it's caused by the snake case to camel case converter being removed.