### PR TITLE
Remove ports in local envoy config

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,4 @@ services:
     command: /usr/local/bin/envoy -c /etc/envoy/envoy.yaml -l debug
     volumes:
       - ./envoy:/etc/envoy
-    ports:
-      - "10000:10000"
-      - "9901:9901"
     network_mode: "host"


### PR DESCRIPTION
Apparently, ports are not allowed (and have no effect even when allowed) when the `network_mode` is set to `host`. @sebastiantoh If this works for you, we can merge this in.