### PR TITLE
Serve content over HTTP/2 and compress responses

### DIFF
--- a/deployment/nginx/nginx.conf
+++ b/deployment/nginx/nginx.conf
@@ -23,6 +23,35 @@ http {
   keepalive_timeout 65;
   types_hash_max_size 2048;
 
+  gzip on;
+  gzip_disable "msie6";
+  gzip_vary on;
+  gzip_proxied any;
+  gzip_comp_level 6;
+  gzip_buffers 16 8k;
+  gzip_http_version 1.1;
+  gzip_min_length 256;
+  gzip_types
+    application/atom+xml
+    application/geo+json
+    application/javascript
+    application/x-javascript
+    application/json
+    application/ld+json
+    application/manifest+json
+    application/rdf+xml
+    application/rss+xml
+    application/xhtml+xml
+    application/xml
+    font/eot
+    font/otf
+    font/ttf
+    image/svg+xml
+    text/css
+    text/javascript
+    text/plain
+    text/xml;
+
   include /etc/nginx/conf.d/*.conf;
   include /etc/nginx/sites-enabled/*;
 }

--- a/deployment/nginx/sites-enabled/hansel-app.com
+++ b/deployment/nginx/sites-enabled/hansel-app.com
@@ -8,7 +8,7 @@
 # 4. first matching regular expression (in order of appearance in a configuration file)
 
 server {
-  listen 80 http2;
+  listen 80;
   server_name hansel-app.com;
 
   # Redirect HTTP to HTTPS
@@ -18,7 +18,7 @@ server {
 }
 
 server {
-  listen 80 http2;
+  listen 80;
   server_name www.hansel-app.com;
 
   # Redirect www to non-www
@@ -47,7 +47,7 @@ server {
 
 # Catch-all for unrecognised requests
 server {
-  listen 80 http2 default_server;
+  listen 80 default_server;
   server_name _;
   return 444;
 }

--- a/deployment/nginx/sites-enabled/hansel-app.com
+++ b/deployment/nginx/sites-enabled/hansel-app.com
@@ -8,7 +8,7 @@
 # 4. first matching regular expression (in order of appearance in a configuration file)
 
 server {
-  listen 80;
+  listen 80 http2;
   server_name hansel-app.com;
 
   # Redirect HTTP to HTTPS
@@ -18,7 +18,7 @@ server {
 }
 
 server {
-  listen 80;
+  listen 80 http2;
   server_name www.hansel-app.com;
 
   # Redirect www to non-www
@@ -26,7 +26,7 @@ server {
 }
 
 server {
-  listen 443 ssl;
+  listen 443 ssl http2;
   server_name hansel-app.com;
   root /build;
   index index.html;
@@ -47,7 +47,7 @@ server {
 
 # Catch-all for unrecognised requests
 server {
-  listen 80 default_server;
+  listen 80 http2 default_server;
   server_name _;
   return 444;
 }


### PR DESCRIPTION
Note that HTTP/2 only works over SSL.