### PR TITLE
Preconnect to required origins

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,11 +1,17 @@
 <!DOCTYPE html>
 <html lang="">
-    <script src="./env.js"></script>
+  <script src="./env.js"></script>
   <head>
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width,initial-scale=1.0">
     <link rel="icon" href="<%= BASE_URL %>favicon.ico">
+
+    <!-- Preconnect to required origins to speed up load times. -->
+    <link rel="preconnect" href="https://storage.googleapis.com">
+    <link rel="preconnect" href="https://maps.googleapis.com">
+    <link rel="preconnect" href="https://www.google-analytics.com">
+
     <title><%= htmlWebpackPlugin.options.title %></title>
   </head>
   <body>


### PR DESCRIPTION
To speed up load times.

I have no idea why `https://storage.googleapis.com` is needed though, presumably by one of the dependencies.