### PR TITLE
Fix incorrect property name in register function call

### DIFF
--- a/frontend/src/pages/LoginRegister/RegisterPage.vue
+++ b/frontend/src/pages/LoginRegister/RegisterPage.vue
@@ -63,7 +63,7 @@ export default defineComponent({
         return;
       }
       this.store.dispatch("register", {
-        fullName: this.fullName,
+        displayName: this.fullName,
         username: this.username,
         password: this.password,
       }).then(() => this.$router.push(HOME_ROUTE))


### PR DESCRIPTION
I hate that this exists outside of the type system.

Fixes #122.