### PR TITLE
Push login page onto router before resetting store

### DIFF
--- a/frontend/src/components/HamburgerMenu.vue
+++ b/frontend/src/components/HamburgerMenu.vue
@@ -55,7 +55,6 @@ import {
   ADD_FRIENDS_ROUTE,
   FRIEND_REQUESTS_ROUTE,
   GEM_LOGS_ROUTE,
-  LOGIN_ROUTE,
 } from "@/constants";
 import { defineComponent, ref, computed } from "vue";
 import { useStore } from "vuex";
@@ -119,7 +118,7 @@ export default defineComponent({
       }
     },
     logOut() {
-      this.store.dispatch("logout").then(() => this.$router.push(LOGIN_ROUTE));
+      this.store.dispatch("logout");
     },
   },
 });

--- a/frontend/src/store/modules/auth.ts
+++ b/frontend/src/store/modules/auth.ts
@@ -7,6 +7,8 @@ import {
 import { RootState } from "@/store";
 import Cookies from "js-cookie";
 import { Module } from "vuex";
+import router from "@/router";
+import { LOGIN_ROUTE } from "@/constants";
 
 const ACCESS_TOKEN_COOKIE = "access-token";
 
@@ -79,8 +81,10 @@ const authModule: Module<AuthState, RootState> = {
     },
     logout({ commit }) {
       commit("clearAccessToken");
-      commit("resetGemsStore");
-      commit("resetUserStore");
+      router.push(LOGIN_ROUTE).then(() => {
+        commit("resetGemsStore");
+        commit("resetUserStore");
+      });
     },
   },
 };


### PR DESCRIPTION
Caused by resetting the store while still on the home page, which results in invalid values for components based off the logged out state.

Fixes #129.