### PR TITLE
Change minimum font size

### DIFF
--- a/frontend/src/index.less
+++ b/frontend/src/index.less
@@ -120,7 +120,7 @@
 
 .content {
   font-family: CircularStd;
-  font-size: 15px;
+  font-size: 16px;
   font-weight: lighter;
   text-align: left;
 }


### PR DESCRIPTION
Safari zooms in all the time on fonts < 16px