### PR TITLE
Fix frontend container being unable to restart

### DIFF
--- a/backend/internal/config/config.go
+++ b/backend/internal/config/config.go
@@ -143,7 +143,7 @@ func loadEnvFromFiles(configFileNames []string) error {
 		if err == nil {
 			return nil
 		}
-		log.Print(fmt.Sprintf("'%s' not found. Loading next config file...", filename))
+		log.Printf("'%s' not found. Loading next config file...", filename)
 	}
 
 	configFileNamesList := strings.Join(configFileNames, ", ")

--- a/deployment/entrypoint-scripts/frontend.sh
+++ b/deployment/entrypoint-scripts/frontend.sh
@@ -3,7 +3,6 @@ set -e
 
 # Replace placeholders in env.js with values from the environment
 envsubst < /build/env.template.js > /build/env.js
-rm -f /build/env.template.js
 
 # Then exec the container's main process (what's set as CMD in the Dockerfile)
 exec "$@"


### PR DESCRIPTION
Do not delete `env.template.js` after substituting environment variables. This will allow future runs of the `hansel-frontend` container to work without having to reset it.

Fixes #186.